### PR TITLE
Force Encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
           type: op.type,
           key: op.key,
           value: op.value,
-          keyEncoding: op.keyEncoding || 'utf8',
-          valueEncoding: op.valueEncoding || 'utf8'
+          keyEncoding: op.keyEncoding || db.options.keyEncoding || 'utf8',
+          valueEncoding: op.valueEncoding || db.options.valueEncoding || 'utf8'
         }
       ]
     }
@@ -105,8 +105,8 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
           type: 'put',
           key: key,
           value: value,
-          keyEncoding: opts.keyEncoding || 'utf8',
-          valueEncoding: opts.valueEncoding || 'utf8'
+          keyEncoding: opts.keyEncoding || db.options.keyEncoding || 'utf8',
+          valueEncoding: opts.valueEncoding || db.options.valueEncoding || 'utf8'
         };
 
         replicate(op, cb)

--- a/index.js
+++ b/index.js
@@ -172,8 +172,8 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
 
           debug('FAILURE EVENT @%s', peer)
 
-          if (repl_opts.minConcensus && ++failures == repl_opts.minConcensus) {
-            return cb(new Error('minimum concensus failed'))
+          if (repl_opts.minConsensus && ++failures == repl_opts.minConsensus) {
+            return cb(new Error('minimum consensus failed'))
           }
         }
         else if (err) {
@@ -216,7 +216,7 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
 
     debug('REPLICATION EVENT @%s', id)
 
-    var len = repl_opts.minConcensus || Object.keys(peers).length
+    var len = repl_opts.minConsensus || Object.keys(peers).length
     if (!len || len == 0) return db.commit(op, cb)
 
     quorumPhase(op, len, function quorumPhaseCallback(err) {
@@ -229,7 +229,7 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
   function connect(peer, index) {
 
     var peername = peer.host + ':' + peer.port
-    var min = repl_opts.minConcensus || repl_opts.peers.length
+    var min = repl_opts.minConsensus || repl_opts.peers.length
     var client = createClient(repl_opts)
 
     client.connect(peer.port, peer.host)
@@ -276,7 +276,7 @@ var Replicator = module.exports = function Replicator(db, repl_opts) {
   }
 
 
-  if (repl_opts.minConcensus == 0) {
+  if (repl_opts.minConsensus == 0) {
     debug('READY EVENT %s', id);
     this._isReady = true;
     this.emit('ready');


### PR DESCRIPTION
The problem is that replicated keys were not having their encoding enforced. If all keys are utf8 this is no problem, however when you start replicating a mix of json and utf8 encoded keys and values, level-2pc was forcing everything to utf8.
- Fixes some namespace variable overlaps with the `opts` variable.
- Force proper key and value encoding using either the value specified when the key was created or by using the defaults provided by the database options.
